### PR TITLE
fix: plugin not working on windows

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -10,6 +10,10 @@ import { ModuleInfo, TransformInfo } from '../types'
 
 const debug = _debug('vite-plugin-inspect')
 
+const isWindows = process.platform === 'win32'
+const windowsRe = /^([A-Z]+):\/(.*)/
+const WindowResolveIdPrefix = '/__resolve_windows/'
+
 export interface Options {
   /**
    * Enable the inspect plugin (could be some performance overhead)
@@ -45,6 +49,7 @@ function PluginInspect(options: Options = {}): Plugin {
 
   const transformMap: Record<string, TransformInfo[]> = {}
   const idMap: Record<string, string> = {}
+  const windowsIdMap: Record<string, string> = {}
 
   function hijackPlugin(plugin: Plugin) {
     if (plugin.transform) {
@@ -52,9 +57,18 @@ function PluginInspect(options: Options = {}): Plugin {
       const _transform = plugin.transform
       plugin.transform = async function(this: any, ...args: any[]) {
         const code = args[0]
-        const id = args[1]
+        let id = args[0]
+        let _result
         const start = Date.now()
-        const _result = await _transform.apply(this, args as any)
+        if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
+          id = windowsIdMap[id]
+          args = new Array<any>(id)
+          args.unshift(...args.splice(1))
+          _result = await _transform.apply(this, args as any)
+        }
+        else {
+          _result = await _transform.apply(this, args as any)
+        }
         const end = Date.now()
 
         const result = typeof _result === 'string' ? _result : _result?.code
@@ -78,7 +92,10 @@ function PluginInspect(options: Options = {}): Plugin {
       debug('hijack plugin load', plugin.name)
       const _load = plugin.load
       plugin.load = async function(this: any, ...args: any[]) {
-        const id = args[0]
+        let id = args[0]
+        if (isWindows && id && id.startsWith(WindowResolveIdPrefix))
+          id = windowsIdMap[id]
+
         const start = Date.now()
         const _result = await _load.apply(this, args as any)
         const end = Date.now()
@@ -96,8 +113,17 @@ function PluginInspect(options: Options = {}): Plugin {
       debug('hijack plugin resolveId', plugin.name)
       const _resolveId = plugin.resolveId
       plugin.resolveId = async function(this: any, ...args: any[]) {
-        const id = args[0]
-        const _result = await _resolveId.apply(this, args as any)
+        let id = args[0]
+        let _result
+        if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
+          id = windowsIdMap[id]
+          args = new Array<any>(id)
+          args.unshift(...args.splice(1))
+          _result = await _resolveId.apply(this, args as any)
+        }
+        else {
+          _result = await _resolveId.apply(this, args as any)
+        }
 
         const result = typeof _result === 'object' ? _result?.id : _result
 
@@ -177,8 +203,16 @@ function PluginInspect(options: Options = {}): Plugin {
         res.end()
       }
       else if (pathname === '/resolve') {
-        const id = parseQuery(search).id as string
-        res.write(JSON.stringify({ id: resolveId(id) }, null, 2))
+        let id = resolveId(parseQuery(search).id as string)
+        if (isWindows) {
+          const match = id.match(windowsRe)
+          if (match) {
+            const original = id
+            id = `${WindowResolveIdPrefix}${match[1]}/${match[2]}`
+            windowsIdMap[id] = original
+          }
+        }
+        res.write(JSON.stringify({ id }, null, 2))
         res.end()
       }
       else if (pathname === '/clear') {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -53,11 +53,10 @@ function PluginInspect(options: Options = {}): Plugin {
 
   function hijackPlugin(plugin: Plugin) {
     function resolveArguments(...args: any[]) {
-      let id = args[0]
-      if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
-        id = windowsIdMap[id]
-        args = new Array<any>(id, ...args.splice(1))
-      }
+      const id = args[0]
+      if (isWindows && id && id.startsWith(WindowResolveIdPrefix))
+        args[0] = windowsIdMap[id]
+
       return args
     }
     if (plugin.transform) {
@@ -68,7 +67,7 @@ function PluginInspect(options: Options = {}): Plugin {
         let id = args[1]
         if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
           id = windowsIdMap[id]
-          args = new Array<any>(code, id, ...args.splice(2))
+          args[1] = id
         }
 
         const start = Date.now()

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -56,8 +56,7 @@ function PluginInspect(options: Options = {}): Plugin {
       let id = args[0]
       if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
         id = windowsIdMap[id]
-        args = new Array<any>(...args.splice(1))
-        args.unshift(id)
+        args = new Array<any>(id, ...args.splice(1))
       }
       return args
     }
@@ -69,8 +68,7 @@ function PluginInspect(options: Options = {}): Plugin {
         let id = args[1]
         if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
           id = windowsIdMap[id]
-          args = new Array<any>(...args.splice(2))
-          args.unshift(code, id)
+          args = new Array<any>(code, id, ...args.splice(2))
         }
 
         const start = Date.now()

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -62,8 +62,8 @@ function PluginInspect(options: Options = {}): Plugin {
         const start = Date.now()
         if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
           id = windowsIdMap[id]
-          args = new Array<any>(id)
-          args.unshift(...args.splice(1))
+          args = new Array<any>(...args.splice(1))
+          args.unshift(id)
           _result = await _transform.apply(this, args as any)
         }
         else {
@@ -93,11 +93,17 @@ function PluginInspect(options: Options = {}): Plugin {
       const _load = plugin.load
       plugin.load = async function(this: any, ...args: any[]) {
         let id = args[0]
-        if (isWindows && id && id.startsWith(WindowResolveIdPrefix))
-          id = windowsIdMap[id]
-
+        let _result
         const start = Date.now()
-        const _result = await _load.apply(this, args as any)
+        if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
+          id = windowsIdMap[id]
+          args = new Array<any>(...args.splice(1))
+          args.unshift(id)
+          _result = await _load.apply(this, args as any)
+        }
+        else {
+          _result = await _load.apply(this, args as any)
+        }
         const end = Date.now()
 
         const result = typeof _result === 'string' ? _result : _result?.code
@@ -117,8 +123,8 @@ function PluginInspect(options: Options = {}): Plugin {
         let _result
         if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
           id = windowsIdMap[id]
-          args = new Array<any>(id)
-          args.unshift(...args.splice(1))
+          args = new Array<any>(...args.splice(1))
+          args.unshift(id)
           _result = await _resolveId.apply(this, args as any)
         }
         else {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -66,8 +66,12 @@ function PluginInspect(options: Options = {}): Plugin {
       const _transform = plugin.transform
       plugin.transform = async function(this: any, ...args: any[]) {
         const code = args[0]
-        args = resolveArguments(args.splice(1))
-        const id = args[1]
+        let id = args[1]
+        if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
+          id = windowsIdMap[id]
+          args = new Array<any>(...args.splice(2))
+          args.unshift(code, id)
+        }
 
         const start = Date.now()
         const _result = await _transform.apply(this, args as any)

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -66,12 +66,9 @@ function PluginInspect(options: Options = {}): Plugin {
       const _transform = plugin.transform
       plugin.transform = async function(this: any, ...args: any[]) {
         const code = args[0]
-        let id = args[1]
-        if (isWindows && id && id.startsWith(WindowResolveIdPrefix)) {
-          id = windowsIdMap[id]
-          args = new Array<any>(...args.splice(2))
-          args.unshift(code, id)
-        }
+        args = resolveArguments(args.splice(1))
+        const id = args[1]
+
         const start = Date.now()
         const _result = await _transform.apply(this, args as any)
         const end = Date.now()


### PR DESCRIPTION
This PR fix the plugin not working on windows: the problem is that the browser requests the asset with `<UNIT>:/` and so the browser (at least chrome) detects the request as a file request `file:///<UNIT>:/....`.

To solve the problem, we intercept the `/__inspect_api/resolve` request on the middleware and transform it to return this url `/__resolve_windows/<UNIT>/....` when the server is running on windows and the `id` matches the following pattern `/^([A-Z]+):\/(.*)/`, where the `<UNIT>` is the first capturing group (maybe we can add also lower case `a-z` but I think it is always on upper case and add `+`, I don't remember the max number of units windows can mount).

The first problem is solved, that is, the browser will not fail when fetching the resolved asset:
```ts
// src/client/pages/index/module.vue::18
async function refetch() {
  /*
  ON WINDOWS NOW THE MIDDLEWARE WILL TRANSFORM THE RESOLVED ID
  FOR     ===>  /__inspect_api/resolve?id=<UNIT>:/...
  TO      ===>  /__resolve_windows/<UNIT>/....
  INSTEAD ===>  <UNIT>:/...
  */
  const { id: resolved } = await fetch(`/__inspect_api/resolve?id=${id.value}`).then(r => r.json())
  if (resolved) {
  // revaluate the module (if it's not initialized by the module graph)
    try { await fetch(resolved) } // ===> HERE THE BROWSER NOW WILL NOT FAIL ON WINDOWS <===
    catch (e) {}
  }
  await execute()
}
```

Then, we need to restore the original id on server when the id starts with `/__resolve_windows/` for:
1) `plugin.transform`, `plugin.load` and `plugin.resolveId`.
2) for middleware on `/__inspect_api`, I don't know if it is necessary to do it on `/module` and `/clear`, since the client will send the orginal asset name on query request and `/list` will return the server names.

closes #2