### PR TITLE
Inspect SSR transform #34

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/src/client/components.d.ts
+++ b/src/client/components.d.ts
@@ -22,6 +22,8 @@ declare module '@vue/runtime-core' {
     CarbonSun: typeof import('~icons/carbon/sun')['default']
     Container: typeof import('./components/Container.vue')['default']
     DiffEditor: typeof import('./components/DiffEditor.vue')['default']
+    EntypoBrowser: typeof import('~icons/entypo/browser')['default']
+    'FaSolid:server': typeof import('~icons/fa-solid/server')['default']
     Graph: typeof import('./components/Graph.vue')['default']
     ModuleId: typeof import('./components/ModuleId.vue')['default']
     ModuleList: typeof import('./components/ModuleList.vue')['default']

--- a/src/client/components/NavBar.vue
+++ b/src/client/components/NavBar.vue
@@ -1,10 +1,22 @@
 <script setup lang="ts">
-import { isDark, refetch, toggleDark } from '../logic'
+import { isDark, refetch, ssr, toggleDark } from '../logic'
+
+function toggleMode() {
+  if (ssr.value) {
+    ssr.value = false
+  } else {
+    ssr.value = true
+  }
+}
 </script>
 
 <template>
   <nav class="font-light px-6 border-b border-main flex gap-4 h-54px children:my-auto">
     <slot />
+    <button class="icon-btn text-lg" title="Transform Mode" @click="toggleMode()">
+      <fa-solid:server v-if="ssr" />
+      <entypo-browser v-else />
+    </button>
     <button class="icon-btn text-lg" title="Refetch" @click="refetch()">
       <carbon:renew />
     </button>

--- a/src/client/components/SearchBox.vue
+++ b/src/client/components/SearchBox.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { includeNodeModules, includeVirtual, searchText } from '../logic'
+import { includeNodeModules, includeVirtual, searchText, ssr } from '../logic'
 </script>
 
 <template>
@@ -8,15 +8,19 @@ import { includeNodeModules, includeVirtual, searchText } from '../logic'
     type="text"
     class="border border-main px-3 py-1 rounded bg-transparent !outline-none"
     placeholder="Search..."
-  >
+  />
   <div class="text-xs flex flex-col h-min">
     <label class="flex">
-      <input v-model="includeNodeModules" type="checkbox" class="my-auto">
+      <input v-model="includeNodeModules" type="checkbox" class="my-auto" />
       <div class="ml-1">node_modules</div>
     </label>
     <label class="flex">
-      <input v-model="includeVirtual" type="checkbox" class="my-auto">
+      <input v-model="includeVirtual" type="checkbox" class="my-auto" />
       <div class="ml-1">virtual</div>
+    </label>
+    <label class="flex">
+      <input v-model="ssr" type="checkbox" class="my-auto" />
+      <div class="ml-1">ssr</div>
     </label>
   </div>
 </template>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-  <title>Vite Inspect</title>
-</head>
-<body>
-  <div id="app"></div>
-  <script>
-    (function() {
-      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-      const setting = localStorage.getItem('color-schema') || 'auto'
-      if (setting === 'dark' || (prefersDark && setting !== 'light'))
-        document.documentElement.classList.toggle('dark', true)
-    })()
-  </script>
-  <script type="module" src="/main.ts"></script>
-</body>
+<html lang="en" data-mode="DEV">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <title>Vite Inspect</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      ;(function () {
+        const prefersDark =
+          window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        const setting = localStorage.getItem('color-schema') || 'auto'
+        if (setting === 'dark' || (prefersDark && setting !== 'light'))
+          document.documentElement.classList.toggle('dark', true)
+      })()
+    </script>
+    <script type="module" src="/main.ts"></script>
+  </body>
 </html>

--- a/src/client/logic/rpc.ts
+++ b/src/client/logic/rpc.ts
@@ -1,5 +1,87 @@
 import { createRPCClient } from 'vite-dev-rpc'
 import { hot } from 'vite-hot-client'
-import type { RPCFunctions } from '../../types'
+import type { ModuleInfo, PluginMetricInfo, RPCFunctions } from '../../types'
 
-export const rpc = createRPCClient<RPCFunctions>('vite-plugin-inspect', hot as any)
+async function createBuildRpcClient(): Promise<RPC> {
+  let root: string
+  let modulesMap: Record<string, { id: string; client?: ModuleInfo; ssr?: ModuleInfo }> = {}
+  try {
+    let json = (await (await fetch('/transforms/ssr/_modules.json')).json()) as {
+      root: string
+      modules: ModuleInfo[]
+    }
+
+    root = json.root
+    json.modules.forEach((m, index) => {
+      modulesMap[m.id] = modulesMap[m.id] || {}
+      modulesMap[m.id].id = m.id
+      modulesMap[m.id].ssr = m
+    })
+  } catch (e) {}
+
+  try {
+    let json = (await (await fetch('/transforms/client/_modules.json')).json()) as {
+      root: string
+      modules: ModuleInfo[]
+    }
+
+    root = json.root
+    json.modules.forEach((m, index) => {
+      modulesMap[m.id] = modulesMap[m.id] || {}
+      modulesMap[m.id].id = m.id
+      modulesMap[m.id].client = m
+    })
+  } catch (e) {}
+
+  let modules = Object.keys(modulesMap)
+    .sort()
+    .map((id) => modulesMap[id])
+
+  return {
+    list: async (ssr?: boolean) => {
+      return {
+        root,
+        modules,
+      }
+    },
+    resolveId(id) {
+      return id
+    },
+    async clear() {},
+    async preloadSSRModule() {},
+    async getPluginMetrics(ssr: boolean) {
+      return (await (
+        await fetch(`/metrics/${ssr ? 'ssr' : 'client'}.json`)
+      ).json()) as PluginMetricInfo[]
+    },
+    async getIdInfo(id, ssr) {
+      let mod = modules.find((i: any) => i.id === id)
+      let m = mod![ssr ? 'ssr' : 'client']
+
+      if (!m) {
+        return {
+          resolvedId: id,
+          transforms: [],
+        }
+      }
+
+      const transforms = await (
+        await fetch(`/transforms/${ssr ? 'ssr' : 'client'}/${m.index}.json`)
+      ).json()
+
+      return {
+        resolvedId: id,
+        transforms: transforms.transforms ?? [],
+      }
+    },
+  }
+}
+
+type RPC = {
+  [k in keyof RPCFunctions]: (...args: any[]) => Promise<any>
+}
+
+export const rpc =
+  document.documentElement.dataset.mode === 'DEV'
+    ? (createRPCClient<RPCFunctions>('vite-plugin-inspect', hot as any) as any)
+    : (createBuildRpcClient() as any)

--- a/src/client/logic/rpc.ts
+++ b/src/client/logic/rpc.ts
@@ -50,9 +50,13 @@ async function createBuildRpcClient(): Promise<RPC> {
     async clear() {},
     async preloadSSRModule() {},
     async getPluginMetrics(ssr: boolean) {
-      return (await (
-        await fetch(`/metrics/${ssr ? 'ssr' : 'client'}.json`)
-      ).json()) as PluginMetricInfo[]
+      try {
+        return (await (
+          await fetch(`/transforms/${ssr ? 'ssr' : 'client'}/_metrics.json`)
+        ).json()) as PluginMetricInfo[]
+      } catch (e) {
+        return []
+      }
     },
     async getIdInfo(id, ssr) {
       let mod = modules.find((i: any) => i.id === id)
@@ -84,4 +88,4 @@ type RPC = {
 export const rpc =
   document.documentElement.dataset.mode === 'DEV'
     ? (createRPCClient<RPCFunctions>('vite-plugin-inspect', hot as any) as any)
-    : (createBuildRpcClient() as any)
+    : ((await createBuildRpcClient()) as any)

--- a/src/client/logic/search.ts
+++ b/src/client/logic/search.ts
@@ -1,28 +1,29 @@
 import { useStorage } from '@vueuse/core'
 import { computed } from 'vue'
 import Fuse from 'fuse.js'
-import { list } from './state'
+import { list, ssr } from './state'
 
 export const searchText = useStorage('vite-inspect-search-text', '')
 export const includeNodeModules = useStorage('vite-inspect-include-node-modules', false)
 export const includeVirtual = useStorage('vite-inspect-include-virtual', false)
 
 export const searchResults = computed(() => {
-  let data = list.value?.modules || []
+  let mods = list.value?.modules || []
 
-  if (!includeNodeModules.value)
-    data = data.filter(item => !item.id.includes('/node_modules/'))
+  let mode = ssr.value ? ('ssr' as 'ssr') : ('client' as 'client')
 
-  if (!includeVirtual.value)
-    data = data.filter(item => !item.virtual)
+  let data = mods.map((d) => d[mode]).filter(Boolean)
 
-  if (!searchText.value)
-    return data
+  if (!includeNodeModules.value) data = data.filter((item) => !item.id.includes('/node_modules/'))
+
+  if (!includeVirtual.value) data = data.filter((item) => !item.virtual)
+
+  if (!searchText.value) return data
 
   const fuse = new Fuse(data, {
     shouldSort: true,
     keys: ['id', 'plugins'],
   })
 
-  return fuse.search(searchText.value).map(i => i.item)
+  return fuse.search(searchText.value).map((i) => i.item)
 })

--- a/src/client/logic/state.ts
+++ b/src/client/logic/state.ts
@@ -6,14 +6,11 @@ export const onRefetch = createEventHook<void>()
 export const enableDiff = useStorage('vite-inspect-diff', true)
 export const listMode = useStorage<'graph' | 'list' | 'detailed'>('vite-inspect-mode', 'detailed')
 export const lineWrapping = useStorage('vite-inspect-line-wrapping', false)
+export const ssr = useStorage('vite-inspect-ssr', true)
 
 export const list = ref(await rpc.list())
 
-const modes = [
-  'detailed',
-  'graph',
-  'list',
-] as const
+const modes = ['detailed', 'graph', 'list'] as const
 
 export function toggleMode() {
   listMode.value = modes[(modes.indexOf(listMode.value) + 1) % modes.length]

--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -14,17 +14,19 @@ const currentIndex = computed(() => +index.value ?? (data.value?.transforms.leng
 
 async function refetch() {
   let resolved = await rpc.resolveId(id.value, ssr.value)
-  if (resolved && !ssr.value) {
-    // revaluate the module (if it's not initialized by the module graph)
-    if (resolved) resolved = `/@fs/${resolved}`
+  if (document.documentElement.dataset.mode === 'DEV') {
+    if (resolved && !ssr.value) {
+      // revaluate the module (if it's not initialized by the module graph)
+      if (resolved) resolved = `/@fs/${resolved}`
 
-    try {
-      await fetch(resolved)
-    } catch (_) {}
-  } else {
-    try {
-      await rpc.preloadSSRModule(resolved)
-    } catch (_) {}
+      try {
+        await fetch(resolved)
+      } catch (_) {}
+    } else {
+      try {
+        await rpc.preloadSSRModule(resolved)
+      } catch (_) {}
+    }
   }
   data.value = await rpc.getIdInfo(id.value, ssr.value)
 }

--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -35,6 +35,7 @@ onRefetch.on(async () => {
 })
 
 watch(id, () => refetch(), { immediate: true })
+watch(ssr, () => refetch(), { immediate: true })
 
 const from = computed(() => data.value?.transforms[currentIndex.value - 1]?.result || '')
 const to = computed(() => data.value?.transforms[currentIndex.value]?.result || '')

--- a/src/client/pages/index/plugins-metric.vue
+++ b/src/client/pages/index/plugins-metric.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
-import { onRefetch } from '../../logic'
+import { onRefetch, ssr } from '../../logic'
 import { rpc } from '../../logic/rpc'
 
-const data = ref(await rpc.getPluginMetics())
+const data = ref(await rpc.getPluginMetics(ssr.value))
 
-const plugins = computed(
-  () => data.value || [],
-)
+const plugins = computed(() => data.value || [])
 
 function getLatencyColor(latency: number) {
-  if (latency > 1000)
-    return 'text-red-400'
-  if (latency > 500)
-    return 'text-orange-400'
-  if (latency > 200)
-    return 'text-yellow-400'
+  if (latency > 1000) return 'text-red-400'
+  if (latency > 500) return 'text-orange-400'
+  if (latency > 200) return 'text-yellow-400'
   return ''
 }
 
 onRefetch.on(async () => {
-  data.value = await rpc.getPluginMetics()
+  data.value = await rpc.getPluginMetics(ssr.value)
 })
 </script>
 
@@ -28,30 +23,32 @@ onRefetch.on(async () => {
     <router-link class="icon-btn !outline-none my-auto" to="/">
       <carbon-arrow-left />
     </router-link>
-    <div class="text-sm font-mono my-auto">
-      Plugins Metrics
-    </div>
+    <div class="text-sm font-mono my-auto">Plugins Metrics</div>
     <div class="flex-auto" />
   </NavBar>
   <Container v-if="data" class="overflow-auto">
-    <div class="mb-4 grid grid-cols-[1fr_max-content_max-content_max-content_max-content_max-content_1fr] mt-2 whitespace-nowrap text-sm font-mono children:(px-4 py-2 border-b border-main align-middle)">
+    <div
+      class="
+        mb-4
+        grid
+        grid-cols-[1fr_max-content_max-content_max-content_max-content_max-content_1fr]
+        mt-2
+        whitespace-nowrap
+        text-sm
+        font-mono
+        children:(px-4
+        py-2
+        border-b border-main
+        align-middle)
+      "
+    >
       <div />
-      <div class="font-bold text-xs">
-        Name ({{ plugins.length }})
-      </div>
-      <div class="font-bold text-xs text-center">
-        Type
-      </div>
-      <div class="font-bold text-xs text-right">
-        Passes
-      </div>
+      <div class="font-bold text-xs">Name ({{ plugins.length }})</div>
+      <div class="font-bold text-xs text-center">Type</div>
+      <div class="font-bold text-xs text-right">Passes</div>
 
-      <div class="font-bold text-xs text-right">
-        Average Time
-      </div>
-      <div class="font-bold text-xs text-right">
-        Total Time
-      </div>
+      <div class="font-bold text-xs text-right">Average Time</div>
+      <div class="font-bold text-xs text-right">Total Time</div>
       <div />
 
       <template v-for="{ name, totalTime, invokeCount, enforce } in plugins" :key="name">
@@ -63,7 +60,9 @@ onRefetch.on(async () => {
           <Badge
             v-if="enforce"
             class="m-auto text-sm"
-            :class="[enforce === 'post' ? 'bg-purple5/10 text-purple5' : 'bg-green5/10 text-green5']"
+            :class="[
+              enforce === 'post' ? 'bg-purple5/10 text-purple5' : 'bg-green5/10 text-green5',
+            ]"
           >
             {{ enforce }}
           </Badge>
@@ -80,15 +79,9 @@ onRefetch.on(async () => {
           </div>
         </template>
         <template v-else>
-          <div class="text-right">
-            -
-          </div>
-          <div class="text-right">
-            -
-          </div>
-          <div class="text-right">
-            -
-          </div>
+          <div class="text-right">-</div>
+          <div class="text-right">-</div>
+          <div class="text-right">-</div>
         </template>
         <div />
       </template>

--- a/src/client/pages/index/plugins-metric.vue
+++ b/src/client/pages/index/plugins-metric.vue
@@ -14,8 +14,14 @@ function getLatencyColor(latency: number) {
 }
 
 onRefetch.on(async () => {
-  data.value = await rpc.getPluginMetics(ssr.value)
+  await refetch()
 })
+
+async function refetch() {
+  data.value = await rpc.getPluginMetics(ssr.value)
+}
+
+watch(ssr, refetch, { immediate: true })
 </script>
 
 <template>

--- a/src/client/pages/index/plugins-metric.vue
+++ b/src/client/pages/index/plugins-metric.vue
@@ -2,7 +2,7 @@
 import { onRefetch, ssr } from '../../logic'
 import { rpc } from '../../logic/rpc'
 
-const data = ref(await rpc.getPluginMetics(ssr.value))
+const data = ref(await rpc.getPluginMetrics(ssr.value))
 
 const plugins = computed(() => data.value || [])
 
@@ -18,7 +18,7 @@ onRefetch.on(async () => {
 })
 
 async function refetch() {
-  data.value = await rpc.getPluginMetics(ssr.value)
+  data.value = await rpc.getPluginMetrics(ssr.value)
 }
 
 watch(ssr, refetch, { immediate: true })

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -36,8 +36,6 @@ export default defineConfig((env) => ({
     Unocss(),
     Inspect({
       clientDir: env.command === 'serve' ? '../dist/client' : '../client',
-      enabled: 'serve',
-      // build: false,
     }),
     AutoImport({
       dts: join(__dirname, 'auto-imports.d.ts'),

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -9,7 +9,7 @@ import AutoImport from 'unplugin-auto-import/vite'
 import Unocss from 'unocss/vite'
 import Inspect from '../node'
 
-export default defineConfig({
+export default defineConfig((env) => ({
   base: '/__inspect/',
 
   resolve: {
@@ -24,9 +24,7 @@ export default defineConfig({
       pagesDir: 'pages',
     }),
     Components({
-      dirs: [
-        'components',
-      ],
+      dirs: ['components'],
       dts: join(__dirname, 'components.d.ts'),
       resolvers: [
         IconsResolver({
@@ -36,21 +34,19 @@ export default defineConfig({
     }),
     Icons(),
     Unocss(),
-    Inspect(),
+    Inspect({
+      clientDir: env.command === 'serve' ? '../dist/client' : '../client',
+      enabled: 'serve',
+      // build: false,
+    }),
     AutoImport({
       dts: join(__dirname, 'auto-imports.d.ts'),
-      imports: [
-        'vue',
-        'vue-router',
-        '@vueuse/core',
-      ],
+      imports: ['vue', 'vue-router', '@vueuse/core'],
     }),
   ],
 
   optimizeDeps: {
-    exclude: [
-      'vite-hot-client',
-    ],
+    exclude: ['vite-hot-client'],
   },
 
   build: {
@@ -59,4 +55,4 @@ export default defineConfig({
     minify: true,
     emptyOutDir: true,
   },
-})
+}))

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -7,13 +7,19 @@ import sirv from 'sirv'
 import type { FilterPattern } from '@rollup/pluginutils'
 import { createFilter } from '@rollup/pluginutils'
 import { createRPCServer } from 'vite-dev-rpc'
-import type { ModuleInfo, PluginMetricInfo, RPCFunctions, TransformInfo } from '../types'
+import type {
+  ModuleInfo,
+  PluginMetricInfo,
+  RPCFunctions,
+  TransformInfo,
+} from '../types'
 
 const debug = _debug('vite-plugin-inspect')
 
-const _dirname = typeof __dirname !== 'undefined'
-  ? __dirname
-  : dirname(fileURLToPath(import.meta.url))
+const _dirname =
+  typeof __dirname !== 'undefined'
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url))
 
 // initial tranform (load from fs)
 const dummyLoadPluginName = '__load__'
@@ -37,9 +43,7 @@ export interface Options {
 }
 
 export default function PluginInspect(options: Options = {}): Plugin {
-  const {
-    enabled = true,
-  } = options
+  const { enabled = true } = options
 
   if (!enabled) {
     return {
@@ -52,7 +56,9 @@ export default function PluginInspect(options: Options = {}): Plugin {
   let config: ResolvedConfig
 
   const transformMap: Record<string, TransformInfo[]> = {}
+  const ssrTransformMap: Record<string, TransformInfo[]> = {}
   const idMap: Record<string, string> = {}
+  const ssrIdMap: Record<string, string> = {}
 
   function hijackPlugin(plugin: Plugin) {
     if (plugin.transform) {
@@ -61,6 +67,9 @@ export default function PluginInspect(options: Options = {}): Plugin {
       plugin.transform = async function (...args) {
         const code = args[0]
         const id = args[1]
+        const ssr = args[2]?.ssr
+
+        let map = ssr ? ssrTransformMap : transformMap
         const start = Date.now()
         const _result = await _transform.apply(this, args)
         const end = Date.now()
@@ -69,13 +78,15 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
         if (filter(id) && result != null) {
           // the last plugin must be `vite:import-analysis`, if it's already there, we reset the stack
-          if (transformMap[id] && transformMap[id].slice(-1)[0]?.name === 'vite:import-analysis')
-            delete transformMap[id]
+          if (map[id] && map[id].slice(-1)[0]?.name === 'vite:import-analysis')
+            delete map[id]
           // initial tranform (load from fs), add a dummy
-          if (!transformMap[id])
-            transformMap[id] = [{ name: dummyLoadPluginName, result: code, start, end: start }]
+          if (!map[id])
+            map[id] = [
+              { name: dummyLoadPluginName, result: code, start, end: start },
+            ]
           // record transform
-          transformMap[id].push({ name: plugin.name, result, start, end })
+          map[id].push({ name: plugin.name, result, start, end })
         }
 
         return _result
@@ -87,14 +98,16 @@ export default function PluginInspect(options: Options = {}): Plugin {
       const _load = plugin.load
       plugin.load = async function (...args) {
         const id = args[0]
+        const ssr = args[1]?.ssr
         const start = Date.now()
         const _result = await _load.apply(this, args)
         const end = Date.now()
 
         const result = typeof _result === 'string' ? _result : _result?.code
 
+        let map = ssr ? ssrTransformMap : transformMap
         if (filter(id) && result != null)
-          transformMap[id] = [{ name: plugin.name, result, start, end }]
+          map[id] = [{ name: plugin.name, result, start, end }]
 
         return _result
       }
@@ -105,35 +118,34 @@ export default function PluginInspect(options: Options = {}): Plugin {
       const _resolveId = plugin.resolveId
       plugin.resolveId = async function (...args) {
         const id = args[0]
+        const ssr = args[2]?.ssr
         const _result = await _resolveId.apply(this, args)
 
         const result = typeof _result === 'object' ? _result?.id : _result
 
         if (!id.startsWith('./') && result && result !== id)
-          idMap[id] = result
+          (ssr ? ssrIdMap : idMap)[id] = result
 
         return _result
       }
     }
   }
 
-  function resolveId(id = ''): string {
-    if (id.startsWith('./'))
-      id = resolve(config.root, id).replace(/\\/g, '/')
-    return resolveIdRec(id)
+  function resolveId(id = '', ssr: boolean): string {
+    if (id.startsWith('./')) id = resolve(config.root, id).replace(/\\/g, '/')
+    return resolveIdRec(id, ssr)
   }
 
-  function resolveIdRec(id: string): string {
-    return idMap[id]
-      ? resolveIdRec(idMap[id])
-      : id
+  function resolveIdRec(id: string, ssr: boolean): string {
+    const map = ssr ? ssrIdMap : idMap
+    return map[id] ? resolveIdRec(map[id], ssr) : id
   }
 
-  function getIdInfo(id: string) {
-    const resolvedId = resolveId(id)
+  function getIdInfo(id: string, ssr = false) {
+    const resolvedId = resolveId(id, ssr)
     return {
       resolvedId,
-      transforms: transformMap[resolvedId] || [],
+      transforms: (ssr ? ssrTransformMap : transformMap)[resolvedId] || [],
     }
   }
 
@@ -149,19 +161,17 @@ export default function PluginInspect(options: Options = {}): Plugin {
       }
     })
 
-    Object.values(transformMap)
-      .forEach((transformInfos) => {
-        transformInfos.forEach(({ name, start, end }) => {
-          if (name === dummyLoadPluginName)
-            return
-          if (!map[name])
-            map[name] = { name, totalTime: 0, invokeCount: 0 }
-          map[name].totalTime += end - start
-          map[name].invokeCount += 1
-        })
+    Object.values(transformMap).forEach((transformInfos) => {
+      transformInfos.forEach(({ name, start, end }) => {
+        if (name === dummyLoadPluginName) return
+        if (!map[name]) map[name] = { name, totalTime: 0, invokeCount: 0 }
+        map[name].totalTime += end - start
+        map[name].invokeCount += 1
       })
+    })
 
-    const metrics = Object.values(map).filter(Boolean)
+    const metrics = Object.values(map)
+      .filter(Boolean)
       .sort((a, b) => a.name.localeCompare(b.name))
       .sort((a, b) => b.invokeCount - a.invokeCount)
       .sort((a, b) => b.totalTime - a.totalTime)
@@ -173,15 +183,30 @@ export default function PluginInspect(options: Options = {}): Plugin {
     const _invalidateModule = server.moduleGraph.invalidateModule
     server.moduleGraph.invalidateModule = function (...args) {
       const mod = args[0]
-      if (mod?.id)
+      if (mod?.id) {
         delete transformMap[mod.id]
+        delete ssrTransformMap[mod.id]
+      }
       return _invalidateModule.apply(this, args)
     }
 
-    server.middlewares.use('/__inspect', sirv(resolve(_dirname, '../dist/client'), {
-      single: true,
-      dev: true,
-    }))
+    server.middlewares.use(
+      '/__inspect',
+      sirv(resolve(_dirname, '../dist/client'), {
+        single: true,
+        dev: true,
+      })
+    )
+
+    async function preloadSSRModule(id: string) {
+      try {
+        await server.ssrLoadModule(id)
+        return {}
+      } catch (e) {
+        console.error(e)
+        return {}
+      }
+    }
 
     createRPCServer<RPCFunctions>('vite-plugin-inspect', server.ws, {
       list,
@@ -189,46 +214,86 @@ export default function PluginInspect(options: Options = {}): Plugin {
       getPluginMetics,
       resolveId,
       clear,
+      preloadSSRModule,
     })
 
     function list() {
-      const modules = Object.keys(transformMap).sort()
-        .map((id): ModuleInfo => {
-          const plugins = transformMap[id]?.map(i => i.name)
-          const deps = Array.from(server.moduleGraph.getModuleById(id)?.importedModules || [])
-            .map(i => i.id || '')
-            .filter(Boolean)
-          return {
-            id,
-            plugins,
-            deps,
-            virtual: plugins[0] !== '__load__',
-          }
-        })
+      const modules: {
+        [k: string]: { client: null | ModuleInfo; ssr: null | ModuleInfo }
+      } = {}
+
+      Object.keys(transformMap).forEach((id) => {
+        const plugins = transformMap[id]?.map((i) => i.name)
+        const deps = Array.from(
+          server.moduleGraph.getModuleById(id)?.importedModules || []
+        )
+          .map((i) => i.id || '')
+          .filter(Boolean)
+
+        modules[id] = modules[id] ?? {}
+        modules[id].client = {
+          id,
+          plugins,
+          deps,
+          ssr: false,
+          virtual: plugins[0] !== '__load__',
+        }
+      })
+
+      Object.keys(ssrTransformMap).forEach((id) => {
+        const plugins = ssrTransformMap[id]?.map((i) => i.name)
+        const deps = Array.from(
+          server.moduleGraph.getModuleById(id)?.importedModules || []
+        )
+          .map((i) => i.id || '')
+          .filter(Boolean)
+
+        modules[id] = modules[id] ?? {}
+        modules[id].ssr = {
+          id,
+          plugins,
+          deps,
+          ssr: true,
+          virtual: plugins[0] !== '__load__',
+        }
+      })
 
       return {
         root: config.root,
-        modules,
+        modules: Object.keys(modules)
+          .sort()
+          .map((id) => modules[id]),
       }
     }
 
     function clear(_id?: string) {
-      const id = resolveId(_id)
-      if (id) {
-        const mod = server.moduleGraph.getModuleById(id)
-        if (mod)
-          server.moduleGraph.invalidateModule(mod)
-        delete transformMap[id]
+      for (var i of [true, false]) {
+        const id = resolveId(_id, i)
+        if (id) {
+          const mod = server.moduleGraph.getModuleById(id)
+          if (mod) server.moduleGraph.invalidateModule(mod)
+          delete transformMap[id]
+          delete ssrTransformMap[id]
+        }
       }
     }
 
     const _print = server.printUrls
     server.printUrls = () => {
-      const colorUrl = (url: string) => green(url.replace(/:(\d+)\//, (_, port) => `:${bold(port)}/`))
-      const host = server.resolvedUrls?.local[0] || `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port || '80'}/`
+      const colorUrl = (url: string) =>
+        green(url.replace(/:(\d+)\//, (_, port) => `:${bold(port)}/`))
+      const host =
+        server.resolvedUrls?.local[0] ||
+        `${config.server.https ? 'https' : 'http'}://localhost:${
+          config.server.port || '80'
+        }/`
       _print()
       // eslint-disable-next-line no-console
-      console.log(`  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(`${host}__inspect/`)}\n`)
+      console.log(
+        `  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(
+          `${host}__inspect/`
+        )}\n`
+      )
     }
   }
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -7,19 +7,12 @@ import sirv from 'sirv'
 import type { FilterPattern } from '@rollup/pluginutils'
 import { createFilter } from '@rollup/pluginutils'
 import { createRPCServer } from 'vite-dev-rpc'
-import type {
-  ModuleInfo,
-  PluginMetricInfo,
-  RPCFunctions,
-  TransformInfo,
-} from '../types'
+import type { ModuleInfo, PluginMetricInfo, RPCFunctions, TransformInfo } from '../types'
 
 const debug = _debug('vite-plugin-inspect')
 
 const _dirname =
-  typeof __dirname !== 'undefined'
-    ? __dirname
-    : dirname(fileURLToPath(import.meta.url))
+  typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
 
 // initial tranform (load from fs)
 const dummyLoadPluginName = '__load__'
@@ -78,13 +71,9 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
         if (filter(id) && result != null) {
           // the last plugin must be `vite:import-analysis`, if it's already there, we reset the stack
-          if (map[id] && map[id].slice(-1)[0]?.name === 'vite:import-analysis')
-            delete map[id]
+          if (map[id] && map[id].slice(-1)[0]?.name === 'vite:import-analysis') delete map[id]
           // initial tranform (load from fs), add a dummy
-          if (!map[id])
-            map[id] = [
-              { name: dummyLoadPluginName, result: code, start, end: start },
-            ]
+          if (!map[id]) map[id] = [{ name: dummyLoadPluginName, result: code, start, end: start }]
           // record transform
           map[id].push({ name: plugin.name, result, start, end })
         }
@@ -106,8 +95,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
         const result = typeof _result === 'string' ? _result : _result?.code
 
         let map = ssr ? ssrTransformMap : transformMap
-        if (filter(id) && result != null)
-          map[id] = [{ name: plugin.name, result, start, end }]
+        if (filter(id) && result != null) map[id] = [{ name: plugin.name, result, start, end }]
 
         return _result
       }
@@ -123,8 +111,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
         const result = typeof _result === 'object' ? _result?.id : _result
 
-        if (!id.startsWith('./') && result && result !== id)
-          (ssr ? ssrIdMap : idMap)[id] = result
+        if (!id.startsWith('./') && result && result !== id) (ssr ? ssrIdMap : idMap)[id] = result
 
         return _result
       }
@@ -149,7 +136,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
     }
   }
 
-  function getPluginMetics() {
+  function getPluginMetics(ssr?: boolean) {
     const map: Record<string, PluginMetricInfo> = {}
 
     config.plugins.forEach((i) => {
@@ -161,7 +148,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
       }
     })
 
-    Object.values(transformMap).forEach((transformInfos) => {
+    Object.values(ssr ? ssrTransformMap : transformMap).forEach((transformInfos) => {
       transformInfos.forEach(({ name, start, end }) => {
         if (name === dummyLoadPluginName) return
         if (!map[name]) map[name] = { name, totalTime: 0, invokeCount: 0 }
@@ -224,9 +211,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
       Object.keys(transformMap).forEach((id) => {
         const plugins = transformMap[id]?.map((i) => i.name)
-        const deps = Array.from(
-          server.moduleGraph.getModuleById(id)?.importedModules || []
-        )
+        const deps = Array.from(server.moduleGraph.getModuleById(id)?.importedModules || [])
           .map((i) => i.id || '')
           .filter(Boolean)
 
@@ -242,9 +227,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
       Object.keys(ssrTransformMap).forEach((id) => {
         const plugins = ssrTransformMap[id]?.map((i) => i.name)
-        const deps = Array.from(
-          server.moduleGraph.getModuleById(id)?.importedModules || []
-        )
+        const deps = Array.from(server.moduleGraph.getModuleById(id)?.importedModules || [])
           .map((i) => i.id || '')
           .filter(Boolean)
 
@@ -284,16 +267,10 @@ export default function PluginInspect(options: Options = {}): Plugin {
         green(url.replace(/:(\d+)\//, (_, port) => `:${bold(port)}/`))
       const host =
         server.resolvedUrls?.local[0] ||
-        `${config.server.https ? 'https' : 'http'}://localhost:${
-          config.server.port || '80'
-        }/`
+        `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port || '80'}/`
       _print()
       // eslint-disable-next-line no-console
-      console.log(
-        `  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(
-          `${host}__inspect/`
-        )}\n`
-      )
+      console.log(`  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(`${host}__inspect/`)}\n`)
     }
   }
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -38,14 +38,18 @@ export interface Options {
   exclude?: FilterPattern
 
   /**
-   * Location of inspect plugin client directory to be served
+   * Location of inspect plugin client directory to be copied from/served in dev
    */
-
   clientDir?: string
+
+  /**
+   * Location of build out
+   */
+  outDir?: string
 }
 
 export default function PluginInspect(options: Options = {}): Plugin {
-  const { enabled = true, clientDir = '../dist/client' } = options
+  const { enabled = true, clientDir = '../dist/client', outDir } = options
 
   if (!enabled) {
     return {
@@ -285,21 +289,20 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
   async function generateBuild() {
     // outputs data to `node_modules/.vite/inspect folder
-    let folder = join(process.cwd(), 'node_modules', '.vite')
+    let folder = outDir
+      ? resolve(config.root, outDir)
+      : join(process.cwd(), 'node_modules', '.vite', 'inspect')
 
     mkdirSync(folder, { recursive: true })
 
-    copySync(join(_dirname, clientDir), join(folder, 'inspect', '__inspect'))
+    copySync(join(_dirname, clientDir), join(folder, '__inspect'))
 
     writeFileSync(
-      join(folder, 'inspect', '__inspect', 'index.html'),
-      readFileSync(join(folder, 'inspect', '__inspect', 'index.html'), 'utf8').replace(
-        'DEV',
-        'BUILD'
-      )
+      join(folder, '__inspect', 'index.html'),
+      readFileSync(join(folder, '__inspect', 'index.html'), 'utf8').replace('DEV', 'BUILD')
     )
 
-    const transforms = join(folder, 'inspect', 'transforms', config.build.ssr ? 'ssr' : 'client')
+    const transforms = join(folder, 'transforms', config.build.ssr ? 'ssr' : 'client')
 
     await rm(transforms, {
       recursive: true,

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -342,6 +342,10 @@ export default function PluginInspect(options: Options = {}): Plugin {
         2
       )
     )
+    writeFileSync(
+      join(transforms, '_metrics.json'),
+      JSON.stringify(getPluginMetrics(Boolean(config.build.ssr)), null, 2)
+    )
 
     modules.forEach((mod, index) => {
       const file = join(transforms, `${index}.json`)

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -136,7 +136,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
     }
   }
 
-  function getPluginMetics(ssr?: boolean) {
+  function getPluginMetrics(ssr?: boolean) {
     const map: Record<string, PluginMetricInfo> = {}
 
     config.plugins.forEach((i) => {
@@ -198,7 +198,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
     createRPCServer<RPCFunctions>('vite-plugin-inspect', server.ws, {
       list,
       getIdInfo,
-      getPluginMetics,
+      getPluginMetrics,
       resolveId,
       clear,
       preloadSSRModule,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,12 @@ export interface ModuleInfo {
   plugins: string[]
   deps: string[]
   virtual: boolean
+  ssr: boolean
 }
 
 export interface ModulesList {
   root: string
-  modules: ModuleInfo[]
+  modules: { client: ModuleInfo; ssr: ModuleInfo }[]
 }
 
 export interface PluginMetricInfo {
@@ -25,12 +26,16 @@ export interface PluginMetricInfo {
 }
 
 export interface RPCFunctions {
-  list(): ModulesList
-  getIdInfo(id: string): {
+  list(ssr?: boolean): ModulesList
+  getIdInfo(
+    id: string,
+    ssr?: boolean
+  ): {
     resolvedId: string
     transforms: TransformInfo[]
   }
-  resolveId(id: string): string
-  getPluginMetics(): PluginMetricInfo[]
-  clear(id: string): void
+  resolveId(id: string, ssr?: boolean): string
+  getPluginMetics(ssr?: boolean): PluginMetricInfo[]
+  preloadSSRModule(id: string): void
+  clear(id: string, ssr?: boolean): void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface ModuleInfo {
   deps: string[]
   virtual: boolean
   ssr: boolean
+  index?: number
 }
 
 export interface ModulesList {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface RPCFunctions {
     transforms: TransformInfo[]
   }
   resolveId(id: string, ssr?: boolean): string
-  getPluginMetics(ssr?: boolean): PluginMetricInfo[]
+  getPluginMetrics(ssr?: boolean): PluginMetricInfo[]
   preloadSSRModule(id: string): void
   clear(id: string, ssr?: boolean): void
 }


### PR DESCRIPTION
Introduces SSR transform inspection.. adds a toggle next to `virtual` and `node_modules`.

`list()` now sends a combined list of modules (both ssr and client) and combines it by `id`, so the returned data structure is:

```json
{
   "modules": [
      { "client": { id, plugins, ... }, "ssr": { id, plugins, ....} },
      { "client": { id, plugins, ... }, "ssr": { id, plugins, ....} },
      { "client": { id, plugins, ... } },
      { "ssr": { id, plugins, ... } },
   ]
}
```

based on the `ssr` toggle, we will see only modules that are available for that mode (modules can be available for both modes).

We also show the plugins for that mode in the list view. And then for the detail module view, based on the toggle, we get the appropriate transforms (ssr or client)

