### PR TITLE
fix: fix redirect not working

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -17,6 +17,8 @@ const debug = _debug('vite-plugin-inspect')
 // initial tranform (load from fs)
 const dummyLoadPluginName = '__load__'
 
+const CLIENT_ROUTE = '/__inspect'
+
 export interface Options {
   /**
    * Enable the inspect plugin in dev mode (could be some performance overhead)
@@ -230,7 +232,13 @@ export default function PluginInspect(options: Options = {}): Plugin {
       return _invalidateModule.apply(this, args)
     }
 
-    server.middlewares.use('/__inspect', sirv(DIR_CLIENT, {
+    server.middlewares.use((req, res, next) => {
+      if (req.originalUrl?.includes(CLIENT_ROUTE))
+        req.url = req.originalUrl
+      next()
+    })
+
+    server.middlewares.use(CLIENT_ROUTE, sirv(DIR_CLIENT, {
       single: true,
       dev: true,
     }))
@@ -300,7 +308,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
       const host = server.resolvedUrls?.local[0] || `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port || '80'}/`
       _print()
       // eslint-disable-next-line no-console
-      console.log(`  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(`${host}__inspect/`)}\n`)
+      console.log(`  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(`${host}${CLIENT_ROUTE}/`)}\n`)
     }
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Sorry, the original [pr/37](https://github.com/antfu/vite-plugin-inspect/pull/37) was closed due to conflicting fixes, so I re-created

When I use `inspect-plugin` and `connect-history-api-fallback` to server.middlewares at the same time, connect-history-api-fallback will redirect req.url to index.html when rewrite is not found , causing inspect-plugin to fail

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
