### PR TITLE
fix: don't generate build when dev mode

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -411,6 +411,8 @@ export default function PluginInspect(options: Options = {}): Plugin {
       },
     },
     async buildEnd() {
+      if (!build)
+        return
       const dir = await generateBuild()
       // eslint-disable-next-line no-console
       console.log(green('Inspect report generated at'), dim(`${dir}`))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`buildEnd` hook is triggered even if in vite dev server.

Reproduction:
```ts
import { createServer } from 'vite'

createServer().then(async (server) => {
  await server.listen()
  server.close()
})
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
