### PR TITLE
fix: remove unnecessary `load` hook

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -402,14 +402,6 @@ export default function PluginInspect(options: Options = {}): Plugin {
       config.plugins.forEach(hijackPlugin)
     },
     configureServer,
-    load: {
-      order: 'pre',
-      handler(id, { ssr } = {}) {
-        const map = ssr ? transformMapSSR : transformMap
-        delete map[id]
-        return null
-      },
-    },
     async buildEnd() {
       if (!build)
         return


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

IMHO, the `load` hook of the plugin is not necessary at all.

Let's take a glance at the logic of [`hijackHood(plugin, 'load')`](https://github.com/antfu/vite-plugin-inspect/blob/main/src/node/index.ts#L144). 

1. first we execute hooks to get the result
2. check whether it's valid 
3. if it's valid, then put in into the map, which refers `transformMap` or `transformMapSSR`.

So we add the correct result into the map in step 3. However, the `load` hook of `vite-plugin-inspect` is executed first in step 1, and there is no corresponding result in the map at this time, because the correct result is obtained by calling the load hooks of other plugins.

I added some console.logs to the hook and tested it in /playground, the result could prove too.

```ts
    load: {
      order: 'pre',
      handler(id, { ssr } = {}) {
        const map = ssr ? transformMapSSR : transformMap
        console.log(id in map)
        delete map[id]
        return null
      },
    },
``` 
![image](https://user-images.githubusercontent.com/73387709/191920639-d914a6a9-8cc4-45cb-9a2f-2bdba1b0ec91.png)



### Linked Issues
None

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
None
