### PR TITLE
fix: follow vite's base

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -4,6 +4,7 @@ import Inspect from 'vite-plugin-inspect'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/test/',
   plugins: [
     vue(),
     Inspect({

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -4,7 +4,6 @@ import Inspect from 'vite-plugin-inspect'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/test/',
   plugins: [
     vue(),
     Inspect({

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -230,7 +230,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
       return _invalidateModule.apply(this, args)
     }
 
-    server.middlewares.use('/__inspect', sirv(DIR_CLIENT, {
+    server.middlewares.use(`${config.base ? config.base : '/'}__inspect`, sirv(DIR_CLIENT, {
       single: true,
       dev: true,
     }))


### PR DESCRIPTION
if config.base is set, the middleware will now be at: "/base-url/__inspect"

fixes #45 
