### PR TITLE
feat: synchronized horizontal scrolling in DiffEditor

### DIFF
--- a/src/client/components/DiffEditor.vue
+++ b/src/client/components/DiffEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { nextTick, onMounted, ref, toRefs, watchEffect } from 'vue'
-import { useCodeMirror } from '../logic/codemirror'
+import { syncCmHorizontalScrolling, useCodeMirror } from '../logic/codemirror'
 import { guessMode } from '../logic/utils'
 import { enableDiff, lineWrapping } from '../logic/state'
 import { calculateDiffWithWorker } from '../worker/diff'
@@ -33,6 +33,8 @@ onMounted(() => {
       scrollbarStyle: 'null',
     },
   )
+
+  syncCmHorizontalScrolling(cm1, cm2)
 
   watchEffect(() => {
     cm1.setOption('lineWrapping', lineWrapping.value)

--- a/src/client/logic/codemirror.ts
+++ b/src/client/logic/codemirror.ts
@@ -51,3 +51,26 @@ export function useCodeMirror(
 
   return cm
 }
+
+export function syncCmHorizontalScrolling(
+  cm1: CodeMirror.EditorFromTextArea,
+  cm2: CodeMirror.EditorFromTextArea,
+) {
+  let activeCm = 1
+
+  cm1.getWrapperElement().addEventListener('mouseenter', () => {
+    activeCm = 1
+  })
+  cm2.getWrapperElement().addEventListener('mouseenter', () => {
+    activeCm = 2
+  })
+
+  cm1.on('scroll', (editor) => {
+    if (activeCm === 1)
+      cm2.scrollTo(editor.getScrollInfo().left)
+  })
+  cm2.on('scroll', (editor) => {
+    if (activeCm === 2)
+      cm1.scrollTo(editor.getScrollInfo().left)
+  })
+}


### PR DESCRIPTION
### Description

This PR synchronizes the horizontal scrolling of the two editors:

![sync-horizontal-scrolling](https://user-images.githubusercontent.com/86521894/197259482-a4ac7236-2916-48db-8eb4-a57a845147b8.gif)

I think this will make it easier for us to compare codes.

### Linked Issues

None

### Additional context

None
