### PR TITLE
feat: redirect when accessed without slash

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -15,6 +15,11 @@
       if (setting === 'dark' || (prefersDark && setting !== 'light'))
         document.documentElement.classList.toggle('dark', true)
     })()
+
+    ;(function () {
+      if (!location.pathname.endsWith('/'))
+        location.pathname += '/'
+    })()
   </script>
   <script type="module" src="/main.ts"></script>
 </body>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When accessing `/__inspect` (instead of `/__inspect/`), vite-plugin-inspect shows an empty page.
This is because `sirv` returns the index.html for `/__inspect` but the relative imported paths doesn't work with that path.

This PR adds a code to redirect `/__inspect` to `/__inspect/`.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
