### PR TITLE
fix: inspect entry url is printed incorrectly when vite's base is configured

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -319,7 +319,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
     const _print = server.printUrls
     server.printUrls = () => {
       const colorUrl = (url: string) => green(url.replace(/:(\d+)\//, (_, port) => `:${bold(port)}/`))
-      const host = server.resolvedUrls?.local[0].replace(/\/$/, '') || `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port || '80'}`
+      const host = server.resolvedUrls?.local[0].replace(base, '').replace(/\/$/, '') || `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port || '80'}`
       _print()
       // eslint-disable-next-line no-console
       console.log(`  ${green('➜')}  ${bold('Inspect')}: ${colorUrl(`${host}${base}__inspect/`)}`)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

![image](https://user-images.githubusercontent.com/21301288/212450601-63db5e37-16f5-4fe4-98f0-94ab2c41ddc0.png)

When vite is configured with [base public path option](https://vitejs.dev/config/shared-options.html#base), the print link to inspect splices the base option twice.

This PR fixes this issue

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fixes https://github.com/antfu/vite-plugin-inspect/issues/56

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
