### PR TITLE
feat: add resolve id metrics

### DIFF
--- a/src/client/components.d.ts
+++ b/src/client/components.d.ts
@@ -35,5 +35,6 @@ declare module '@vue/runtime-core' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SearchBox: typeof import('./components/SearchBox.vue')['default']
+    SegmentControl: typeof import('./components/SegmentControl.vue')['default']
   }
 }

--- a/src/client/components/SegmentControl.vue
+++ b/src/client/components/SegmentControl.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+  options: { label: string; value: string }[]
+  modelValue: string
+}>()
+defineEmits<{
+  (event: 'update:modelValue', newValue: string): void
+}>()
+</script>
+
+<template>
+  <div class="flex overflow-hidden rounded border border-main divide-x divide-gray-400 divide-opacity-30">
+    <button
+      v-for="option in options"
+      :key="option.value"
+      class="text-sm font-mono px-2 py-1"
+      :class="{ 'bg-black dark:bg-white bg-opacity-10 dark:bg-opacity-10': option.value === modelValue }"
+      :aria-pressed="option.value === modelValue"
+      @click="$emit('update:modelValue', option.value)"
+    >
+      {{ option.label }}
+    </button>
+  </div>
+</template>

--- a/src/client/logic/state.ts
+++ b/src/client/logic/state.ts
@@ -8,6 +8,7 @@ export const showOneColumn = useStorage('vite-inspect-one-column', false)
 export const listMode = useStorage<'graph' | 'list' | 'detailed'>('vite-inspect-mode', 'detailed')
 export const lineWrapping = useStorage('vite-inspect-line-wrapping', false)
 export const inspectSSR = useStorage('vite-inspect-ssr', false)
+export const metricDisplayHook = useStorage<'transform' | 'resolveId'>('vite-inspect-metric-display-hook', 'transform')
 
 export const list = ref(await rpc.list())
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,14 @@ export interface TransformInfo {
   order?: string
 }
 
+export interface ResolveIdInfo {
+  name: string
+  result: string
+  start: number
+  end: number
+  order?: string
+}
+
 export interface ModuleInfo {
   id: string
   plugins: string[]
@@ -28,9 +36,15 @@ export interface ModuleTransformInfo {
 
 export interface PluginMetricInfo {
   name: string
-  totalTime: number
-  invokeCount: number
   enforce?: string
+  transform: {
+    invokeCount: number
+    totalTime: number
+  }
+  resolveId: {
+    invokeCount: number
+    totalTime: number
+  }
 }
 
 export interface RPCFunctions {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The "plugins metrics" section currently only shows the `transform` metrics. This PR adds the `resolveId` metrics as well.

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/34116392/226186111-bcad80a9-8231-4709-a9c5-0cff06b7e3c9.png">


### Linked Issues

none

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Added this to set up a sort of benchmarking suite for Vite, but I realized it usually doesn't show much info (maybe that's the reason it wasn't implemented), especially during build. I found it was easier to `DEBUG="vite:resolve"` instead 🤔 

Since I already implemented it, I thought to just submit it.