### PR TITLE
perf: use virtual list in module list

### DIFF
--- a/src/client/components/ModuleList.vue
+++ b/src/client/components/ModuleList.vue
@@ -1,39 +1,58 @@
 <script setup lang="ts">
 import { listMode, searchText } from '../logic'
 
-defineProps<{
+const props = defineProps<{
   modules: Array<{
     id: string
     plugins: any[]
   }>
 }>()
+
+const { list, containerProps, wrapperProps } = useVirtualList(
+  toRef(props, 'modules'),
+  {
+    itemHeight: listMode.value === 'detailed' ? 53 : 37,
+  },
+)
 </script>
 
 <template>
-  <div v-if="modules">
+  <div v-if="modules" class="h-full">
     <div v-if="!modules.length" px-6 py-4 italic op50>
       <div v-if="searchText">
         No search result
       </div>
       <div v-else>
-        No module recorded yet, visit <a href="/" target="_blank">your app</a> first and then refresh this page.
+        No module recorded yet, visit
+        <a href="/" target="_blank">your app</a> first and then refresh this
+        page.
       </div>
     </div>
-    <RouterLink
-      v-for="m in modules"
-      :key="m.id"
-      class="block border-b border-main px-3 py-2 text-left font-mono text-sm"
-      :to="`/module?id=${encodeURIComponent(m.id)}`"
-    >
-      <ModuleId :id="m.id" />
-      <div v-if="listMode === 'detailed'" text-xs op50>
-        <template v-for="i, idx in m.plugins.slice(1).filter(plugin => plugin.transform !== undefined)" :key="i">
-          <span v-if="idx !== 0" op20>|</span>
-          <span class="mx-0.5">
-            <PluginName :name="i.name" :hide="true" />
-          </span>
-        </template>
+
+    <div v-else v-bind="containerProps" class="h-full">
+      <div v-bind="wrapperProps">
+        <RouterLink
+          v-for="m in list"
+          :key="m.data.id"
+          class="block border-b border-main px-3 py-2 text-left font-mono text-sm"
+          :to="`/module?id=${encodeURIComponent(m.data.id)}`"
+        >
+          <ModuleId :id="m.data.id" />
+          <div v-if="listMode === &quot;detailed&quot;" text-xs op50>
+            <template
+              v-for="(i, idx) in m.data.plugins
+                .slice(1)
+                .filter((plugin) => plugin.transform !== undefined)"
+              :key="i"
+            >
+              <span v-if="idx !== 0" op20>|</span>
+              <span class="mx-0.5">
+                <PluginName :name="i.name" :hide="true" />
+              </span>
+            </template>
+          </div>
+        </RouterLink>
       </div>
-    </RouterLink>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

i am using this plugin with a more that 2000 modules project, and it always block the UI when searching. So this PR use the virtual list to avoid directly render all the list item.
