### PR TITLE
fix: incorrect diff content in module page

### DIFF
--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Ref } from 'vue'
 import { useRouteQuery } from '@vueuse/router'
 import { Pane, Splitpanes } from 'splitpanes'
 import { msToTime } from '../../logic/utils'
@@ -10,8 +9,8 @@ import { getHot } from '../../logic/hot'
 
 const id = useRouteQuery<string | undefined>('id')
 const data = ref(id.value ? await rpc.getIdInfo(id.value, inspectSSR.value) : undefined)
-const index = useRouteQuery('index') as Ref<string>
-const currentIndex = computed(() => +index.value ?? (data.value?.transforms.length || 1) - 1 ?? 0)
+const index = useRouteQuery<string | undefined>('index')
+const currentIndex = computed(() => (index.value != null ? +index.value : null) ?? (data.value?.transforms.length || 1) - 1)
 const panelSize = useLocalStorage('vite-inspect-module-panel-size', '10')
 
 async function refetch() {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Diff content would be latest file when click a new module file, because route query `index` may be undefined, cause `currentIndex` to be NaN. This is related to `vueuse`'s change on `useRouteQuery`, since https://github.com/vueuse/vueuse/pull/2191.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
