### PR TITLE
fix: handle `[null]` in `sourcemaps.sources` for inspect sourcemaps button

### DIFF
--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -35,10 +35,13 @@ const sourcemaps = computed(() => {
   if (!sourcemaps?.mappings)
     return
 
-  if (sourcemaps && !sourcemaps.sourcesContent) {
-    sourcemaps.sourcesContent = []
-    sourcemaps.sourcesContent[0] = from.value
-  }
+  if (sourcemaps && !sourcemaps.sourcesContent?.filter(Boolean)?.length)
+    sourcemaps.sourcesContent = [from.value]
+
+  // sometimes sources is [null]
+  if (sourcemaps && !sourcemaps.sources?.filter(Boolean)?.length)
+    sourcemaps.sources = ['index.js']
+
   return JSON.stringify(sourcemaps)
 })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Sometimes `sources` is `[null]` after an SSR transform, the visualizer code expect this field be an array of strings

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
