### PR TITLE
fix: fix build entry

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,7 +2,7 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: [
-    'src/index',
+    'src/node/index',
     'src/nuxt',
   ],
   clean: false,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The commit [c585e0e](https://github.com/antfu/vite-plugin-inspect/commit/c585e0eb35a25c637bdc414c1213acbafbea7fbb) seems to have caused an issue in @nuxt/devtools by changing the entry point in build.config.ts from `src/node/index` to `src/index`.
Current PR basically reverts this part of the aforementioned commit, so that everything works again. With that being said, it is possible that there is another way to tackle the problem saving the new logic.

### Linked Issues
[Cannot start nuxt: The requested module 'vite-plugin-inspect' does not provide an export named 'default' ](https://github.com/nuxt/nuxt/issues/23493)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
