### PR TITLE
fix: default CJS exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       },
       "require": {
@@ -31,7 +31,7 @@
     },
     "./nuxt": {
       "import": {
-        "types": "./dist/nuxt.d.ts",
+        "types": "./dist/nuxt.d.mts",
         "default": "./dist/nuxt.mjs"
       },
       "require": {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,23 +1,16 @@
-import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 function patchCjs(cjsModulePath: string, name: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
+  const cjsFile = `${cjsModulePath}.cjs`
+  const cjsModule = readFileSync(cjsFile, 'utf-8')
   writeFileSync(
-    cjsModulePath,
-    cjsModule.replace(`module.exports = ${name};`, `exports.default = ${name};`),
+    cjsFile,
+    cjsModule.replace(`module.exports = ${name};`, `exports.default = ${name};\nexports.__esModule = true;`),
+    // cjsModule.replace(`module.exports = ${cjsName};`, `module.exports = ${cjsName};\nexports.default = ${cjsName};`),
     { encoding: 'utf-8' },
   )
 }
 
-rmSync(resolve('./dist/index.d.mts'))
-rmSync(resolve('./dist/nuxt.d.mts'))
-
-readdirSync('./dist/shared')
-  .filter(file => file.endsWith('.d.mts'))
-  .forEach((file) => {
-    rmSync(resolve('./dist/shared', file))
-  })
-
-patchCjs(resolve('./dist/index.cjs'), 'PluginInspect')
-patchCjs(resolve('./dist/nuxt.cjs'), 'nuxt')
+patchCjs(resolve('./dist/index'), 'PluginInspect')
+patchCjs(resolve('./dist/nuxt'), 'nuxt')

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -2,15 +2,14 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 function patchCjs(cjsModulePath: string, name: string) {
-  const cjsFile = `${cjsModulePath}.cjs`
-  const cjsModule = readFileSync(cjsFile, 'utf-8')
+  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
   writeFileSync(
-    cjsFile,
+    cjsModulePath,
     cjsModule.replace(`module.exports = ${name};`, `exports.default = ${name};\nexports.__esModule = true;`),
     // cjsModule.replace(`module.exports = ${cjsName};`, `module.exports = ${cjsName};\nexports.default = ${cjsName};`),
     { encoding: 'utf-8' },
   )
 }
 
-patchCjs(resolve('./dist/index'), 'PluginInspect')
-patchCjs(resolve('./dist/nuxt'), 'nuxt')
+patchCjs(resolve('./dist/index.cjs'), 'PluginInspect')
+patchCjs(resolve('./dist/nuxt.cjs'), 'nuxt')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR includes:
- add `exports.__esModule=true;` to cjs modules, Vite working (tested with 4.5.0 and 5.0.4: CJS deprecation warning now missing in Vite 5)
- don't remove `d.mts` files, using them in package exports

### Linked Issues

closes #100 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Downloaded https://stackblitz.com/edit/vitejs-vite-9ncgh5?file=main.js to local and using a local copy of this PR:

Vite 4:
![imagen](https://github.com/antfu/vite-plugin-inspect/assets/6311119/a08ef9e9-1dd4-49b8-a17c-72fcbdff42c4)

Vite 5:
![imagen](https://github.com/antfu/vite-plugin-inspect/assets/6311119/dffcc6bf-d64e-42aa-a025-346aa996d4b2)

