### PR TITLE
feat: make module update reactive by rpc functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "debug": "^4.3.4",
     "error-stack-parser-es": "^0.1.1",
     "fs-extra": "^11.1.1",
+    "lodash-es": "^4.17.21",
     "open": "^9.1.0",
     "picocolors": "^1.0.0",
     "sirv": "^2.0.3"
@@ -98,6 +99,7 @@
     "@types/debug": "^4.1.12",
     "@types/diff-match-patch": "^1.0.36",
     "@types/fs-extra": "^11.0.4",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.10.0",
     "@unocss/eslint-config": "^0.57.7",
     "@unocss/eslint-plugin": "^0.57.7",

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,7 +10,8 @@
     "build-inspect": "serve .vite-inspect"
   },
   "dependencies": {
-    "vue": "^3.3.8"
+    "vue": "^3.3.8",
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.5.0",

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,9 +1,18 @@
 <script setup lang="ts">
-// This starter template is using Vue 3 <script setup> SFCs
-// Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
-import HelloWorld from './components/HelloWorld.vue'
+import { RouterLink, RouterView } from 'vue-router'
 </script>
 
 <template>
-  <HelloWorld msg="Vite + Vue" />
+  <main>
+    <nav>
+      <RouterLink to="/">
+        Home
+      </RouterLink>
+      <RouterLink to="/other">
+        Other
+      </RouterLink>
+    </nav>
+
+    <RouterView />
+  </main>
 </template>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,5 +1,8 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.use(router)
+app.mount('#app')

--- a/playground/src/router/index.ts
+++ b/playground/src/router/index.ts
@@ -1,0 +1,20 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import Home from '../views/Home.vue'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      name: 'home',
+      path: '/',
+      component: Home,
+    },
+    {
+      name: 'other',
+      path: '/other',
+      component: () => import('../views/Other.vue'),
+    },
+  ],
+})
+
+export default router

--- a/playground/src/views/Home.vue
+++ b/playground/src/views/Home.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+// This starter template is using Vue 3 <script setup> SFCs
+// Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
+import HelloWorld from '../components/HelloWorld.vue'
+</script>
+
+<template>
+  <HelloWorld msg="Vite + Vue" />
+</template>

--- a/playground/src/views/Other.vue
+++ b/playground/src/views/Other.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Other</div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       open:
         specifier: ^9.1.0
         version: 9.1.0
@@ -57,6 +60,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.0
@@ -1876,6 +1882,16 @@ packages:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
       '@types/node': 20.10.0
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.14.202
+    dev: true
+
+  /@types/lodash@4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
     dev: true
 
   /@types/mdast@3.0.15:
@@ -5067,6 +5083,10 @@ packages:
     dependencies:
       p-locate: 6.0.0
     dev: true
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       vue:
         specifier: ^3.3.8
         version: 3.3.8(typescript@5.2.2)
+      vue-router:
+        specifier: ^4.2.5
+        version: 4.2.5(vue@3.3.8)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.5.0
@@ -2407,7 +2410,6 @@ packages:
 
   /@vue/devtools-api@6.5.1:
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
-    dev: true
 
   /@vue/language-core@1.8.22(typescript@5.3.2):
     resolution: {integrity: sha512-bsMoJzCrXZqGsxawtUea1cLjUT9dZnDsy5TuZ+l1fxRMzUGQUG9+Ypq4w//CqpWmrx7nIAJpw2JVF/t258miRw==}
@@ -7308,6 +7310,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /vue-router@4.2.5(vue@3.3.8):
+    resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      '@vue/devtools-api': 6.5.1
+      vue: 3.3.8(typescript@5.2.2)
+    dev: false
 
   /vue-router@4.2.5(vue@3.3.9):
     resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}

--- a/src/client/logic/rpc.ts
+++ b/src/client/logic/rpc.ts
@@ -2,6 +2,7 @@ import { createRPCClient } from 'vite-dev-rpc'
 import type { BirpcReturn } from 'birpc'
 import { createHotContext } from 'vite-hot-client'
 import type { ModuleTransformInfo, RPCFunctions } from '../../types'
+import { refetch } from './state'
 
 export const isStaticMode = document.body.getAttribute('data-vite-inspect-mode') === 'BUILD'
 
@@ -31,9 +32,14 @@ function createStaticRpcClient(): RPCFunctions {
       return {}
     },
     getIdInfo,
+    moduleUpdated() {},
   }
 }
 
 export const rpc = isStaticMode
   ? createStaticRpcClient() as BirpcReturn<RPCFunctions>
-  : createRPCClient<RPCFunctions>('vite-plugin-inspect', (await createHotContext('/___', `${location.pathname.split('/__inspect')[0] || ''}/`.replace(/\/\//g, '/')))!)
+  : createRPCClient<RPCFunctions, Pick<RPCFunctions, 'moduleUpdated'>>('vite-plugin-inspect', (await createHotContext('/___', `${location.pathname.split('/__inspect')[0] || ''}/`.replace(/\/\//g, '/')))!, {
+    moduleUpdated() {
+      refetch()
+    },
+  })

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface RPCFunctions {
   clear(id: string, ssr: boolean): Awaitable<void>
   getPluginMetrics(ssr: boolean): Awaitable<PluginMetricInfo[]>
   getServerMetrics(): Awaitable<Record<string, Record<string, { name: string, self: number, total: number }[]>>>
+  moduleUpdated(): void
 }
 
 export interface HMRData {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is to make module update reactive by rpc functions.

The original issue is [devtools-next #177](https://github.com/vuejs/devtools-next/issues/177). It is expected that after loading lazy-load resources, eg. changing routes with vue-router, the `Graph.vue` should update in real-time which is powered by `vite-plugin-inspect`.

This plugin has a similar problem.

What I do in this PR

- add vue-router in the `playground` to match the repro
- add a simple middleware in vite dev server which is used for checking if some new resources will be loading ( ❗❗❗I'm not sure if it's an appropriate way to do this. )
- add a new `moduleUpdated` rpc function for server and client communication and trigger `refetch` in client-side

Check procedures

- nr dev:client
- cd playground && nr dev
- click the RouterLink `Other` to load a laze-load resource
- `Other.vue` will show on the `/__inspect` in real-time

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
